### PR TITLE
fix --o-angle-composite formular for satellite, side and vector

### DIFF
--- a/src/scss/_satellite.scss
+++ b/src/scss/_satellite.scss
@@ -2,7 +2,7 @@
 .satellite {
   container-name: satellite;
   --o-size-ratio: 1;
-  --o-angle-composite: (var(--o-angle) * var(--o-orbit-child-number) var(--o-offset, + 270deg)) * var(--o-direction, 1);
+  --o-angle-composite: (var(--o-angle) * var(--o-orbit-child-number) + var(--o-offset, 270deg)) * var(--o-direction, 1);
   --o-transform: translate(
     calc(
       (var(--o-radius) - var(--o-aligment, 0px))  / var(--o-ellipse-x) *

--- a/src/scss/_side.scss
+++ b/src/scss/_side.scss
@@ -2,7 +2,7 @@
 
 .side {
   container-name: side;
-  --o-angle-composite: (var(--o-angle) * var(--o-orbit-child-number) var(--o-offset, + 270deg)) * var(--o-direction, 1);
+  --o-angle-composite: (var(--o-angle) * var(--o-orbit-child-number) + var(--o-offset, 270deg)) * var(--o-direction, 1);
   --o-y: calc(var(--o-radius) * sin(90deg - var(--o-angle) / 2));
   --o-x: calc(var(--o-radius) * cos(90deg - var(--o-angle) / 2) * 2);
   --o-transform: rotate( calc(var(--o-from) + var(--o-angle-composite)))

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -161,7 +161,7 @@ Can be used in parent elements or in each orbiter class
 
 .ccw{
   --o-direction: -1 !important;
-  --o-offset: - -90deg !important;
+  --o-offset: 90deg !important;
 }
 
 /* 

--- a/src/scss/_vector.scss
+++ b/src/scss/_vector.scss
@@ -2,7 +2,7 @@
 
 .vector {
   container-name: vector;
-  --o-angle-composite: (var(--o-angle) * var(--o-orbit-child-number) var(--o-offset, + 270deg)) * var(--o-direction, 1);
+  --o-angle-composite: (var(--o-angle) * var(--o-orbit-child-number) + var(--o-offset, 270deg)) * var(--o-direction, 1);
   --o-transform: translate(
     calc(
       (var(--o-radius) - var(--o-aligment, 1px)) / var(--o-ellipse-x) *


### PR DESCRIPTION
Hi, 

This PR provides a fix for minor issues in the --o-angle-composite formulas for satellite, side and vector. 

This caused the layout to break completely in my Next.js application when using a prod build.

Best regards!